### PR TITLE
Send separate bulk requests for each token

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,8 +71,9 @@ function SpmAgent (spmUrl) {
   }.bind(this))
 
   // registering for send events, and emitting updated counters as 'stats' event
-  this.influxSender.on('send', function () {
+  this.influxSender.on('send', function (info) {
     counters.send += 1
+    counters.lastBulkSize = info.count
     this.emit('stats', counters)
   }.bind(this))
   this.influxSender.on('sendFailed', function (e) {

--- a/lib/sender/influxsender.js
+++ b/lib/sender/influxsender.js
@@ -95,7 +95,10 @@ InfluxSender.prototype.collectMetric = function (metric) {
     if (!metric.timestamp) {
       metric.timestamp = new Date()
     }
-    this.datapoints.push(metric)
+    if (!this.datapoints[metric.tags.token]) {
+      this.datapoints[metric.tags.token] = []
+    }
+    this.datapoints[metric.tags.token].push(metric)
     this.emit('metricInSendBuffer', metric)
     // logger.debug('InfluxSender: add metric ' + JSON.stringify(metric))
   } else {
@@ -103,50 +106,63 @@ InfluxSender.prototype.collectMetric = function (metric) {
   }
 }
 
-InfluxSender.prototype.sendMetrics = function () {
+InfluxSender.prototype.sendBulkRequest = function (datapointsToShip, token, next) {
   const self = this
-  if (self.datapoints && self.datapoints.length === 0) {
-    // nothing to do
-    return
-  }
-  var reqSize = Math.min(this.datapoints.length, 100)
-  var datapointsToShip = this.datapoints.slice(0, reqSize)
-  this.datapoints = this.datapoints.slice(reqSize, this.datapoints.length)
+  logger.error('Sending ')
   self.influx.writePoints(datapointsToShip)
     .then(() => {
-      const msg = 'InfluxSender: ' + self.datapoints.length + ' data points successfully sent to ' + self.influxUrl
+      const msg = `InfluxSender:  ${datapointsToShip.length} data points successfully sent to ${self.influxUrl} token: ${token}`
       logger.debug(msg)
       this.emit('send', {
         msg: msg,
         count: datapointsToShip.length,
         url: self.influxUrl
       })
-      // more metrics to ship?
-      if (self.datapoints.length > 0) {
-        this.sendMetrics()
-      }
+      next()
     })
     .catch((err) => {
+      next(err)
+    })
+}
+
+InfluxSender.prototype.sendMetrics = function () {
+  const self = this
+  const tokens = Object.keys(self.datapoints)
+  tokens.forEach((token) => {
+    if (self.datapoints[token] && self.datapoints[token].length === 0) {
+      // nothing to do
+      return
+    }
+    let reqSize = Math.min(self.datapoints[token].length, 100)
+    let datapointsToShip = self.datapoints[token].slice(0, reqSize)
+    self.datapoints[token] = self.datapoints[token].slice(reqSize, self.datapoints[token].length)
+    console.log(`InfluxSender:  ${datapointsToShip.length} data points successfully sent to ${self.influxUrl} token: ${token}`)
+    self.sendBulkRequest(datapointsToShip, token, (err) => {
       if (err) {
         // error obj contains: err.req, err.res, err.body
         if (err.res && err.res.statusCode &&
             err.res.statusCode > 399 &&
             err.res.statusCode < 500) {
             // receiver rejected the metrics, so we drop the metrics
-          logger.warn(`InfluxSender: receiver rejected metrics with status code ${err.res.statusCode} '${err.message || ''}'`)
+          logger.warn(`InfluxSender: receiver rejected metrics with token ${token}, status code ${err.res.statusCode} '${err.message || ''}'`)
           self.emit('send', {cound: datapointsToShip.length})
         } else {
           // add metrics back to ring-buffer, if the buffer will not reach maxBufferSize
-          if (self.datapoints.length <= (self.maxBufferSize - datapointsToShip.length)) {
-            self.datapoints = self.datapoints.concat(datapointsToShip)
+          if (self.datapoints[token].length <= (self.maxBufferSize - datapointsToShip.length)) {
+            self.datapoints[token] = self.datapoints[token].concat(datapointsToShip)
           }
           self.emit('sendFailed', {msg: err.message})
-          logger.error(`InfluxSender: error sending metrics ${err}`)
+          logger.error(`InfluxSender: error sending metrics with token ${token} ${err}`)
         }
       } else {
-        self.emit('sendFailed', {msg: 'unknown error'})
+        self.emit('sendFailed', {msg: `InfluxSender: unknown error sending metrics with token ${token}`})
+      }
+      // more metrics to ship?
+      if (self.datapoints[token].length > 0) {
+        self.sendMetrics()
       }
     })
+  })
 }
 
 InfluxSender.prototype.sendClientInfo = function (action, terminate) {

--- a/lib/sender/influxsender.js
+++ b/lib/sender/influxsender.js
@@ -136,7 +136,6 @@ InfluxSender.prototype.sendMetrics = function () {
     let reqSize = Math.min(self.datapoints[token].length, 100)
     let datapointsToShip = self.datapoints[token].slice(0, reqSize)
     self.datapoints[token] = self.datapoints[token].slice(reqSize, self.datapoints[token].length)
-    console.log(`InfluxSender:  ${datapointsToShip.length} data points successfully sent to ${self.influxUrl} token: ${token}`)
     self.sendBulkRequest(datapointsToShip, token, (err) => {
       if (err) {
         // error obj contains: err.req, err.res, err.body


### PR DESCRIPTION
It is possible to use multiple app tokens. A bulk request would fail if one of the tokens is not valid. Separating the bulk requests for each token ensures that metrics with valid tokens are accepted by the receiver. Only bulk requests with invalid tokens would fail.  